### PR TITLE
Add sensitive support to telegraf::plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,22 @@ telegraf::plugin { '[inputs.logparser.nginx_access_log]':
   }
 }
 ```
+
+Sensitive values example:
+
+When a plugin config contains a secret (e.g. a DSN with a password), set
+`sensitive => true` and wrap the secret value in `Sensitive(...)`. The plaintext
+is still written to the telegraf config file (telegraf needs it), but the
+rendered file content is wrapped in `Sensitive`, so the secret does not leak
+into the catalog, reports or run diffs.
+
+```puppet
+telegraf::plugin { '[inputs.mysql.db]':
+  plugin_name => '[inputs.mysql]',
+  sensitive   => true,
+  conf        => {
+    'metric_version' => 2,
+    'servers'        => [Sensitive("telegraf:${password}@tcp(127.0.0.1:3306)/")],
+  },
+}
+```

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -2,14 +2,21 @@ define telegraf::plugin (
   Variant[String, Integer] $order       = '10',
   Optional[Hash]           $conf        = undef,
   Optional[String]         $plugin_name = undef,
+  Boolean                  $sensitive   = false,
 ) {
 
   $real_name = pick($plugin_name, $title) ### used for fragment.erb
 
+  # Hide the rendered config from catalog/reports when it contains secrets.
+  $content = $sensitive ? {
+    true    => Sensitive(template('telegraf/fragment.erb')),
+    default => template('telegraf/fragment.erb'),
+  }
+
   $plugin_file = regsubst($title, '\[|\]', '', 'G')
   file { "/etc/telegraf/telegraf.d/${order}-${plugin_file}.conf":
     ensure  => file,
-    content => template('telegraf/fragment.erb'),
+    content => $content,
     notify  => Service[$telegraf::service_name],
   }
 

--- a/templates/fragment.erb
+++ b/templates/fragment.erb
@@ -1,5 +1,7 @@
 <%-
 def dumpvar(var)
+  var = var.unwrap if var.respond_to?(:unwrap) # unwrap Sensitive values
+
   case var
     when String
       if var =~ /^\{/


### PR DESCRIPTION
## What

Adds a way to safely pass secrets (passwords, DSNs) into a `telegraf::plugin` config.

- New `Boolean $sensitive = false` parameter on `telegraf::plugin`. When `true`, the rendered config `content` is wrapped in `Sensitive()`, so the secret never leaks into the catalog, reports or run diffs.
- `templates/fragment.erb`: `dumpvar` now unwraps any `Sensitive` value (`respond_to?(:unwrap)`) before rendering — telegraf needs the plaintext in the file itself. Plain values are unaffected, so the change is backward compatible.
- README: usage example.

## Why

Without this, a plugin config containing a password (e.g. `inputs.mysql` `servers` DSN) writes the secret as a plain catalog value, which fails security review. `Sensitive(...)` couldn't be used before because the ERB template rendered it as `Sensitive [value redacted]`.

## Usage

```puppet
telegraf::plugin { '[inputs.mysql.db]':
  plugin_name => '[inputs.mysql]',
  sensitive   => true,
  conf        => {
    'metric_version' => 2,
    'servers'        => [Sensitive("telegraf:${password}@tcp(127.0.0.1:3306)/")],
  },
}
```